### PR TITLE
Update segment trees

### DIFF
--- a/bench/SegTreeBench.hs
+++ b/bench/SegTreeBench.hs
@@ -30,9 +30,9 @@ benchfromListST n = sizedBench n gen $ nf $ fromListST (1, n) where
 benchAdjustST :: Int -> Benchmark
 benchAdjustST n = sizedBench n gen $ \ ~(st, us) -> nf (go st) us where
     gen = (emptyST (1, n), evalR $ zip <$> randIntsR (1, n) n <*> (map Sum <$> randInts n))
-    go st us = foldl' (\st (i, x) -> adjustST (const x) i st) st us
+    go = foldl' (\st (i, x) -> adjustST (const x) i st)
 
 benchFoldRangeST :: Int -> Benchmark
 benchFoldRangeST n = sizedBench n gen $ \ ~(st, qs) -> whnf (go st) qs where
     gen = (emptyST (1, n) :: SegTree (Sum Int), evalR $ randSortedIntPairsR (1, n) n)
-    go st qs = foldl' (\_ (i, j) -> foldRangeST i j st `seq` ()) () qs
+    go st = foldl' (\_ (i, j) -> foldRangeST i j st `seq` ()) ()

--- a/bench/SegTreeLazyBench.hs
+++ b/bench/SegTreeLazyBench.hs
@@ -9,7 +9,7 @@ import Criterion
 
 import SegTreeLazy
     ( LazySegTree
-    , LazySegTreeUpd(..)
+    , Action(..)
     , adjustLST
     , emptyLST
     , foldRangeLST
@@ -50,8 +50,8 @@ instance Monoid SumLen where
 -- Can add a value to all elements in a range
 type RangeAddSegTree = LazySegTree (Sum Int) SumLen
 
-instance LazySegTreeUpd (Sum Int) SumLen where
-    applyUpd (SumLen s l) (Sum u) = SumLen (s + u * l) l
+instance Action (Sum Int) SumLen where
+    act (SumLen s l) (Sum u) = SumLen (s + u * l) l
 
 benchfromListLST :: Int -> Benchmark
 benchfromListLST n = sizedBench n gen $ nf $ go (1, n) where

--- a/src/SegTree.hs
+++ b/src/SegTree.hs
@@ -42,7 +42,7 @@ foldRangeST
 Folds the elements in the range (ql, qr). Elements outside (l, r) are considered to be mempty.
 O(log n).
 
-SegTree implementable Foldable. foldMap takes O(n).
+SegTree implementable Foldable. Folding over all the elements takes O(n).
 -}
 
 module SegTree
@@ -111,10 +111,10 @@ foldRangeST ql qr (SegTree (l, _, p) root) = go root l (l + p - 1) mempty where
         where m = (l + r) `div` 2
 
 instance Foldable SegTree where
-    foldMap f (SegTree (l, r', p) root) = go root l (l + p - 1) where
-        go _ l _ | l > r' = mempty
+    foldr f z (SegTree (l, r', p) root) = go root l (l + p - 1) z where
+        go _ l _ | l > r' = id
         go (SLeaf x)      _ _ = f x
-        go (SBin _ lt rt) l r = go lt l m <> go rt (m + 1) r where m = (l + r) `div` 2
+        go (SBin _ lt rt) l r = go lt l m . go rt (m + 1) r where m = (l + r) `div` 2
 
 --------------------------------------------------------------------------------
 -- For tests

--- a/src/SegTreeLazy.hs
+++ b/src/SegTreeLazy.hs
@@ -45,8 +45,9 @@ foldRangeST
 Folds the elements in the range (ql, qr). Elements outside (l, r) are considered to be mempty.
 O(log n).
 
-toListLST
-Gets the elements of the segment tree as a list. O(n).
+foldrLST
+Right fold over the elements of the segment tree. O(n).
+LazySegTree u cannot be Foldable because of the Action constraint :(
 -}
 
 module SegTreeLazy
@@ -58,7 +59,7 @@ module SegTreeLazy
     , adjustLST
     , updateRangeLST
     , foldRangeLST
-    , toListLST
+    , foldrLST
     ) where
 
 import Control.DeepSeq
@@ -140,10 +141,10 @@ foldRangeLST ql qr (LazySegTree (l, _, p) root) = go root l (l + p - 1) mempty m
         m = (l + r) `div` 2
         u' = u <> pu
 
-toListLST :: Action u a => LazySegTree u a -> [a]
-toListLST (LazySegTree (l, r', p) root) = go root l (l + p - 1) mempty [] where
+foldrLST :: Action u a => (a -> b -> b) -> b -> LazySegTree u a -> b
+foldrLST f z (LazySegTree (l, r', p) root) = go root l (l + p - 1) mempty z where
     go _ l _ _ | l > r' = id
-    go (LSLeaf x)        _ _ pu = (act x pu :)
+    go (LSLeaf x)        _ _ pu = f (act x pu)
     go (LSBin _ u lt rt) l r pu = go lt l m u' . go rt (m + 1) r u' where
         m = (l + r) `div` 2
         u' = u <> pu

--- a/src/SegTreeLazy.hs
+++ b/src/SegTreeLazy.hs
@@ -15,12 +15,14 @@ See SegTree.hs because the structure is identical. The only difference is that e
 update here.
 
 LazySegTree u a is a segment tree on elements of type a and updates of type u. a and u must be
-monoids. An instance of LazySegTreeUpd u a must exist, where applyUpd a u applies u to a.
-The following must hold:
-* (x1 <> x2) `applyUpd` u = (x1 `applyUpd` u) <> (x2 `applyUpd` u)
-* x `applyUpd` (u1 <> u2) = (x `applyUpd` u1) `applyUpd` u2
+monoids. An instance of Action u a must exist, which specifies a (right) monoid action of u on a.
+The following laws hold for a monoid action:
+* (x `act` u1) `act` u2 = x `act` (u1 <> u2)
+* x `act` mempty = x
+The segment tree requires an additional law:
+* (x1 <> x2) `act` u = (x1 `act` u) <> (x2 `act` u)
 
-The complexities below assume mappend for u, mappend for a and applyUpd all take O(1) time.
+The complexities below assume <> for u, <> for a and act all take O(1) time.
 Let n = r - l + 1 in all instances below.
 
 emptyST
@@ -49,7 +51,7 @@ Gets the elements of the segment tree as a list. O(n).
 
 module SegTreeLazy
     ( LazySegTree
-    , LazySegTreeUpd(..)
+    , Action(..)
     , emptyLST
     , fromListLST
     , boundsLST
@@ -66,10 +68,10 @@ import Data.Bits
 data LazySegTree u a = LazySegTree !(Int, Int, Int) !(LSegNode u a) deriving Show
 data LSegNode u a = LSLeaf !a | LSBin !a !u !(LSegNode u a) !(LSegNode u a) deriving Show
 
-class (Monoid u, Monoid a) => LazySegTreeUpd u a where
-    applyUpd :: a -> u -> a
+class (Monoid u, Monoid a) => Action u a where
+    act :: a -> u -> a
 
-buildLST :: LazySegTreeUpd u a => (Int, Int) -> (Int -> LSegNode u a) -> LazySegTree u a
+buildLST :: Action u a => (Int, Int) -> (Int -> LSegNode u a) -> LazySegTree u a
 buildLST (l, r) f
     | n < -1    = error "invalid range"
     | n == -1   = LazySegTree (l, r, 0) $ LSLeaf mempty
@@ -78,17 +80,17 @@ buildLST (l, r) f
     n = r - l
     ht = finiteBitSize n - countLeadingZeros n
 
-emptyLST :: LazySegTreeUpd u a => (Int, Int) -> LazySegTree u a
+emptyLST :: Action u a => (Int, Int) -> LazySegTree u a
 emptyLST bnds = buildLST bnds go where
     go j | j == 0 = LSLeaf mempty
     go j = LSBin mempty mempty lr lr where lr = go $ j - 1
 
-makeLSN :: LazySegTreeUpd u a => LSegNode u a -> LSegNode u a -> LSegNode u a
+makeLSN :: Action u a => LSegNode u a -> LSegNode u a -> LSegNode u a
 makeLSN lt rt = LSBin (getx lt <> getx rt) mempty lt rt where
     getx (LSLeaf x)      = x
     getx (LSBin x _ _ _) = x
 
-fromListLST :: LazySegTreeUpd u a => (Int, Int) -> [a] -> LazySegTree u a
+fromListLST :: Action u a => (Int, Int) -> [a] -> LazySegTree u a
 fromListLST bnds xs = buildLST bnds (flip evalState xs . go) where
     pop = state go where
         go []     = (mempty, [])
@@ -99,22 +101,22 @@ fromListLST bnds xs = buildLST bnds (flip evalState xs . go) where
 boundsLST :: LazySegTree u a -> (Int, Int)
 boundsLST (LazySegTree (l, r, _) _) = (l, r)
 
-applyLSN :: LazySegTreeUpd u a => LSegNode u a -> u -> LSegNode u a
-applyLSN (LSLeaf x)        u' = LSLeaf $ applyUpd x u'
-applyLSN (LSBin x u lt rt) u' = LSBin (applyUpd x u') (u <> u') lt rt
+applyLSN :: Action u a => LSegNode u a -> u -> LSegNode u a
+applyLSN (LSLeaf x)        u' = LSLeaf $ act x u'
+applyLSN (LSBin x u lt rt) u' = LSBin (act x u') (u <> u') lt rt
 
-adjustLST :: LazySegTreeUpd u a => (a -> a) -> Int -> LazySegTree u a -> LazySegTree u a
+adjustLST :: Action u a => (a -> a) -> Int -> LazySegTree u a -> LazySegTree u a
 adjustLST f i (LazySegTree lrp@(l, r, p) root)
     | i < l || r < i = error "outside range"
     | otherwise      = LazySegTree lrp $ go root l (l + p - 1) mempty
   where
     go n l r pu | i < l || r < i = applyLSN n pu
-    go (LSLeaf x)        _ _ pu = LSLeaf $ f $ applyUpd x pu
+    go (LSLeaf x)        _ _ pu = LSLeaf $ f $ act x pu
     go (LSBin _ u lt rt) l r pu = makeLSN (go lt l m u') (go rt (m + 1) r u') where
         m = (l + r) `div` 2
         u' = u <> pu
 
-updateRangeLST :: LazySegTreeUpd u a => u -> Int -> Int -> LazySegTree u a -> LazySegTree u a
+updateRangeLST :: Action u a => u -> Int -> Int -> LazySegTree u a -> LazySegTree u a
 updateRangeLST qu ql qr (LazySegTree lrp@(l, r, p) root)
     | ql < l || r < qr = error "outside range"
     | otherwise        = LazySegTree lrp $ go root l (l + p - 1) mempty
@@ -126,22 +128,22 @@ updateRangeLST qu ql qr (LazySegTree lrp@(l, r, p) root)
         m = (l + r) `div` 2
         u' = u <> pu
 
-foldRangeLST :: LazySegTreeUpd u a => Int -> Int -> LazySegTree u a -> a
+foldRangeLST :: Action u a => Int -> Int -> LazySegTree u a -> a
 foldRangeLST ql qr _ | ql > qr + 1 = error "invalid range"
 foldRangeLST ql qr (LazySegTree (l, _, p) root) = go root l (l + p - 1) mempty mempty where
     go _ l r _ acc | r < ql || qr < l = acc
-    go (LSLeaf x) _ _ pu acc = acc <> applyUpd x pu
+    go (LSLeaf x) _ _ pu acc = acc <> act x pu
     go (LSBin x u lt rt) l r pu acc
-        | ql <= l && r <= qr = acc <> applyUpd x pu
+        | ql <= l && r <= qr = acc <> act x pu
         | otherwise          = go rt (m + 1) r u' $! go lt l m u' acc
       where
         m = (l + r) `div` 2
         u' = u <> pu
 
-toListLST :: LazySegTreeUpd u a => LazySegTree u a -> [a]
+toListLST :: Action u a => LazySegTree u a -> [a]
 toListLST (LazySegTree (l, r', p) root) = go root l (l + p - 1) mempty [] where
     go _ l _ _ acc | l > r' = acc
-    go (LSLeaf x)        _ _ pu acc = applyUpd x pu : acc
+    go (LSLeaf x)        _ _ pu acc = act x pu : acc
     go (LSBin _ u lt rt) l r pu acc = go lt l m u' $ go rt (m + 1) r u' acc where
         m = (l + r) `div` 2
         u' = u <> pu

--- a/tests/SegTreeLazySpec.hs
+++ b/tests/SegTreeLazySpec.hs
@@ -11,7 +11,7 @@ import Test.QuickCheck
 
 import SegTreeLazy
     ( LazySegTree
-    , LazySegTreeUpd(..)
+    , Action(..)
     , adjustLST
     , boundsLST
     , foldRangeLST
@@ -70,8 +70,8 @@ spec = do
 type RangeAddSegTree = LazySegTree (Sum Int) SumLen
 type SumLen = (Sum Int, Sum Int)
 
-instance LazySegTreeUpd (Sum Int) SumLen where
-    applyUpd (s, l) u = (s + u * l, l)
+instance Action (Sum Int) SumLen where
+    act (s, l) u = (s + u * l, l)
 
 genSt :: Gen RangeAddSegTree
 genSt = sized $ \n -> do

--- a/tests/SegTreeLazySpec.hs
+++ b/tests/SegTreeLazySpec.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE FlexibleContexts, FlexibleInstances, MultiParamTypeClasses, TupleSections #-}
+{-# LANGUAGE FlexibleInstances, MultiParamTypeClasses, TupleSections #-}
 module SegTreeLazySpec where
 
 import Data.Array
@@ -56,14 +56,14 @@ spec = do
             let (l, r) = boundsLST st
                 n = r - l + 1
             forAll (vector n :: Gen [Sum Int]) $ \xs -> do
-                let st' = fromListLST (l, r) $ map (,1) xs :: LazySegTree (Sum Int) SumLen
+                let st' = fromListLST (l, r) $ map (,1) xs :: RangeAddSegTree
                     st'' = adjustMany st (zip [l..] xs)
                 toListLST st' `shouldBe` toListLST st''
 
   where
     naive ivs i j = fold [v | (k, v) <- ivs, i <= k && k <= j]
-    adjustMany st ivs = foldl' (\st (i, v) -> adjustLST (\(x, _) -> (x <> v, 1)) i st) st ivs
-    applyRangeUpdates st ijvs = foldl' (\st (i, j, v) -> updateRangeLST v i j st) st ijvs
+    adjustMany = foldl' (\st (i, v) -> adjustLST (\(x, _) -> (x <> v, 1)) i st)
+    applyRangeUpdates = foldl' (\st (i, j, v) -> updateRangeLST v i j st)
 
 
 -- Can add a value to all elements in a range

--- a/tests/SegTreeLazySpec.hs
+++ b/tests/SegTreeLazySpec.hs
@@ -16,7 +16,7 @@ import SegTreeLazy
     , boundsLST
     , foldRangeLST
     , fromListLST
-    , toListLST
+    , foldrLST
     , updateRangeLST
     )
 import SegTreeSpec ( pointUpds, rangeQry )
@@ -32,13 +32,13 @@ spec = do
                 forAll (rangeQry bnds) $ \(i, j) ->
                     fst (foldRangeLST i j st') `shouldBe` naive ivs i j
 
-    prop "multiple adjustLST then toListLST works ok" $
+    prop "elements are as expected after multiple adjustLST" $
         forAll genSt $ \st -> do
             let bnds = boundsLST st
             forAll (pointUpds bnds) $ \ivs -> do
                 let st' = adjustMany st ivs
                     xs = elems $ accumArray (<>) mempty bnds ivs
-                map fst (toListLST st') `shouldBe` xs
+                foldrLST ((:) . fst) [] st' `shouldBe` xs
 
     prop "multiple updateRangeLST then foldRangeLST works ok" $
         forAll genSt $ \st -> do
@@ -58,7 +58,7 @@ spec = do
             forAll (vector n :: Gen [Sum Int]) $ \xs -> do
                 let st' = fromListLST (l, r) $ map (,1) xs :: RangeAddSegTree
                     st'' = adjustMany st (zip [l..] xs)
-                toListLST st' `shouldBe` toListLST st''
+                foldrLST (:) [] st' `shouldBe` foldrLST (:) [] st''
 
   where
     naive ivs i j = fold [v | (k, v) <- ivs, i <= k && k <= j]

--- a/tests/SegTreeSpec.hs
+++ b/tests/SegTreeSpec.hs
@@ -40,7 +40,7 @@ spec = do
 
   where
     naive ivs i j = fold [v | (k, v) <- ivs, i <= k && k <= j]
-    adjustMany st ivs = foldl' (\st (i, v) -> adjustST (v <>) i st) st ivs
+    adjustMany = foldl' (\st (i, v) -> adjustST (v <>) i st)
 
 genSt :: Gen (SegTree (Sum Int))
 genSt = sized $ \n -> do


### PR DESCRIPTION
- Rename `LazySegTreeUpd` to `Action`
I wasn't previously aware the proper name for it is a monoid action.
- Implement `foldr` for SegTree and LazySegTree
Instead of the previously implemented `foldMap` and `toList`.
- Other minor changes